### PR TITLE
Update docker-compose.yml to use environment variable for host port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     container_name: hapi
     image: "hapiproject/hapi:v8.2.0-1" # updated to >8 since External Terminology Service work from there
     ports:
-      - "8080:8080"
+      - "${HOST_PORT:-8080}:8080"
     configs:
       - source: hapi
         target: /app/config/application.yaml


### PR DESCRIPTION
On steamdeck setup I needed dynamic hosts since port 8080 is used by other applications and I need to be able to run things rootless.